### PR TITLE
feat: WriteScreen 및 관련 컴포넌트 반응형 UI 적용 및 개선

### DIFF
--- a/app/src/main/java/com/example/ouralbum/presentation/component/AppTopBar.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/AppTopBar.kt
@@ -1,0 +1,48 @@
+package com.example.ouralbum.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import com.example.ouralbum.ui.util.Dimension
+
+@Composable
+fun AppTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+    heightPercent: Float = 0.06f,
+    fontPercent: Float = 0.025f,
+    style: TextStyle = MaterialTheme.typography.displaySmall,
+    containerColor: Color = MaterialTheme.colorScheme.background
+) {
+    val height = Dimension.scaledHeight(heightPercent)
+    val fontSize = Dimension.scaledFont(fontPercent)
+
+    Column {
+        // 상단바 배경 + 중앙 텍스트
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(height)
+                .background(containerColor),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = title,
+                fontSize = fontSize,
+                style = style.copy(fontSize = fontSize),
+                maxLines = 1
+            )
+        }
+
+        if (showDivider) {
+            AppDivider()
+        }
+    }
+}

--- a/app/src/main/java/com/example/ouralbum/presentation/component/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/BottomNavigationBar.kt
@@ -14,10 +14,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.example.ouralbum.presentation.navigation.NavigationItem
+import com.example.ouralbum.ui.util.Dimension
 
 @Composable
 fun CustomBottomNavigationBar(
@@ -32,13 +31,18 @@ fun CustomBottomNavigationBar(
         NavigationItem.MyPage
     )
 
+    val navBarHeight = Dimension.scaledHeight(0.06f) // 예: 화면 높이의 7%
+    val iconSize = Dimension.scaledWidth(0.07f) // 예: 화면 너비의 7%
+    val paddingVertical = Dimension.scaledHeight(0.01f)
+    val paddingHorizontal = Dimension.scaledWidth(0.02f)
+
     Column {
         AppDivider()
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp)
-                .background(Color.White),
+                .height(navBarHeight)
+                .background(MaterialTheme.colorScheme.background),
             horizontalArrangement = Arrangement.SpaceAround,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -61,14 +65,14 @@ fun CustomBottomNavigationBar(
                                 }
                             }
                         }
-                        .padding(vertical = 2.dp, horizontal = 6.dp),
+                        .padding(vertical = paddingVertical, horizontal = paddingHorizontal),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = item.icon,
                         contentDescription = item.label,
                         tint = if (selected) Color.Black else Color.Gray,
-                        modifier = Modifier.size(28.dp)
+                        modifier = Modifier.size(iconSize)
                     )
                 }
             }

--- a/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
@@ -12,41 +12,46 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.ouralbum.domain.model.Photo
 import com.example.ouralbum.ui.theme.bodyLargeBold
+import com.example.ouralbum.ui.util.Dimension
 
 @Composable
 fun PhotoCard(
     photo: Photo,
     onBookmarkClick: () -> Unit
 ) {
+    val fontSizeTitle = Dimension.scaledFont(0.02f)     // 제목 글씨 크기
+    val fontSizeDate = Dimension.scaledFont(0.018f)     // 날짜 글씨 크기
+    val iconSize = Dimension.scaledWidth(0.06f)         // 아이콘 크기 (화면 너비 기준)
+    val paddingHorizontal = Dimension.paddingSmall()
+    val paddingVertical = Dimension.scaledHeight(0.01f)
+
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = Modifier.fillMaxWidth()
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .padding(horizontal = paddingHorizontal, vertical = paddingVertical),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = photo.title,
-                style = MaterialTheme.typography.bodyLargeBold,
+                style = MaterialTheme.typography.bodyLargeBold.copy(fontSize = fontSizeTitle),
                 modifier = Modifier.weight(1f)
             )
 
             Text(
                 text = photo.date,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(end = 8.dp)
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeDate),
+                modifier = Modifier.padding(end = paddingHorizontal)
             )
 
             IconButton(
                 onClick = onBookmarkClick,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(iconSize)
             ) {
                 Icon(
                     imageVector = if (photo.isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
@@ -61,7 +66,7 @@ fun PhotoCard(
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(1f)
+                .aspectRatio(1f) // 정사각형 비율 유지
         )
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/component/TagPeopleSelector.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/TagPeopleSelector.kt
@@ -1,0 +1,93 @@
+package com.example.ouralbum.presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import com.example.ouralbum.ui.util.Dimension
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TagPeopleSelector(
+    allPeople: List<String>,
+    selectedPeople: List<String>,
+    onSelectionChange: (List<String>) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var query by remember { mutableStateOf("") }
+
+    // 선택된 사람이 바뀌면 검색어 초기화
+    LaunchedEffect(selectedPeople) {
+        query = ""
+    }
+
+    val filtered = allPeople.filter {
+        it.contains(query, ignoreCase = true) && it !in selectedPeople
+    }
+
+    val spacingSmall = Dimension.scaledWidth(0.02f)
+    val spacingTiny = Dimension.scaledWidth(0.01f)
+    val textFontSize = Dimension.scaledFont(0.018f)
+    val chipFontSize = Dimension.scaledFont(0.016f)
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacingSmall)
+    ) {
+        // 검색창
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            placeholder = {
+                Text("함께한 사람을 검색하세요", fontSize = textFontSize)
+            },
+            textStyle = LocalTextStyle.current.copy(fontSize = textFontSize),
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+
+        // 추천 인물: 선택 전 상태 (outlined 스타일)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+            verticalArrangement = Arrangement.spacedBy(spacingTiny)
+        ) {
+            filtered.take(5).forEach { person ->
+                AssistChip(
+                    onClick = {
+                        if (person !in selectedPeople) {
+                            onSelectionChange(selectedPeople + person)
+                        }
+                    },
+                    label = { Text(person, fontSize = chipFontSize) },
+                    // 선택 전: 기본 outlined 스타일
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        labelColor = MaterialTheme.colorScheme.onSurface
+                    )
+                )
+            }
+        }
+
+        // 선택된 인물: filled 스타일
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+            verticalArrangement = Arrangement.spacedBy(spacingTiny)
+        ) {
+            selectedPeople.forEach { person ->
+                AssistChip(
+                    onClick = {
+                        // 클릭 시 선택 해제 (옵션)
+                        onSelectionChange(selectedPeople - person)
+                    },
+                    label = { Text(person, fontSize = chipFontSize) },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        labelColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.ouralbum.presentation.component.AppDivider
+import com.example.ouralbum.presentation.component.AppTopBar
 import com.example.ouralbum.presentation.component.PhotoCard
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -22,23 +23,9 @@ fun GalleryScreen(viewModel: GalleryViewModel = hiltViewModel()) {
 
     Scaffold(
         topBar = {
-            Column {
-                CenterAlignedTopAppBar(
-                    title = {
-                        Text(
-                            text = "Our Album",
-                            style = MaterialTheme.typography.displaySmall,
-                            maxLines = 1
-                        )
-                    },
-                    modifier = Modifier.height(48.dp),
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background
-                    )
-                )
-                AppDivider()
-            }
-
+            AppTopBar(
+                title = "My Album"
+            )
         }
     ) { paddingValues ->
         if (isLoggedIn) {

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.ouralbum.presentation.component.AppDivider
+import com.example.ouralbum.presentation.component.AppTopBar
 import com.example.ouralbum.presentation.component.PhotoCard
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -18,22 +19,9 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
 
     Scaffold(
         topBar = {
-            Column {
-                CenterAlignedTopAppBar(
-                    title = {
-                        Text(
-                            text = "Our Album",
-                            style = MaterialTheme.typography.displaySmall,
-                            maxLines = 1
-                        )
-                    },
-                    modifier = Modifier.height(48.dp),
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background
-                    )
-                )
-                AppDivider()
-            }
+            AppTopBar(
+                title = "Our Album"
+            )
         }
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteScreen.kt
@@ -1,9 +1,124 @@
 package com.example.ouralbum.presentation.screen.write
 
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.ouralbum.presentation.component.AppDivider
+import com.example.ouralbum.presentation.component.AppTopBar
+import com.example.ouralbum.presentation.component.TagPeopleSelector
+import com.example.ouralbum.ui.util.Dimension
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WriteScreen() {
-    Text("글쓰기 화면입니다")
+fun WriteScreen(viewModel: WriteViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val sectionSpacing = Dimension.scaledHeight(0.015f)
+    val contentHeight = Dimension.scaledHeight(0.07f)
+    val tagSelectorHeight = Dimension.scaledHeight(0.20f)
+    val bottomBarHeight = Dimension.scaledHeight(0.1f)
+
+    val contentFontSize = Dimension.scaledFont(0.02f)
+    val buttonFontSize = Dimension.scaledFont(0.025f)
+
+    val horizontalPadding = Dimension.paddingSmall()
+
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = "New Post"
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(bottomBarHeight)
+                    .padding(vertical = sectionSpacing,horizontal = horizontalPadding),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = { /* 저장 처리 */ },
+                    modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("게시하기", fontSize = buttonFontSize)
+                }
+            }
+        }
+
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(horizontal = horizontalPadding)
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(sectionSpacing)
+        ) {
+            Spacer(modifier = Modifier.height(Dimension.scaledHeight(0.0f)))
+
+            // 제목 입력
+            OutlinedTextField(
+                value = uiState.title,
+                onValueChange = { viewModel.onTitleChange(it) },
+                placeholder = { Text("제목을 적어주세요") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(contentHeight),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    fontSize = contentFontSize
+                ),
+                singleLine = true
+            )
+
+            // 본문 입력
+            OutlinedTextField(
+                value = uiState.content,
+                onValueChange = { viewModel.onContentChange(it) },
+                placeholder = { Text("사진 속 함께 했던 추억을 적어주세요.") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(contentHeight),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    fontSize = contentFontSize
+                ),
+                singleLine = true
+            )
+
+            // 함께한 사람 선택창
+            TagPeopleSelector(
+                allPeople = listOf("김철수", "최영희", "강진영", "이지윤", "박영철"),
+                selectedPeople = uiState.selectedPeople,
+                onSelectionChange = { viewModel.onSelectedPeopleChange(it) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(tagSelectorHeight)
+            )
+
+            // 이미지 업로드 영역
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f) // 정사각형 비율
+                    .background(Color.LightGray, shape = RoundedCornerShape(8.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add Photo", tint = Color.Gray)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteUiState.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteUiState.kt
@@ -1,0 +1,7 @@
+package com.example.ouralbum.presentation.screen.write
+
+data class WriteUiState(
+    val title: String = "",
+    val content: String = "",
+    val selectedPeople: List<String> = listOf("김철수", "최영희", "강진영")
+)

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteViewModel.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/write/WriteViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.ouralbum.presentation.screen.write
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class WriteViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(WriteUiState())
+    val uiState: StateFlow<WriteUiState> = _uiState
+
+    fun onTitleChange(newTitle: String) {
+        _uiState.value = _uiState.value.copy(title = newTitle)
+    }
+
+    fun onContentChange(newContent: String) {
+        _uiState.value = _uiState.value.copy(content = newContent)
+    }
+
+    fun onSelectedPeopleChange(newList: List<String>) {
+        _uiState.value = _uiState.value.copy(selectedPeople = newList)
+    }
+}

--- a/app/src/main/java/com/example/ouralbum/utils/Dimension.kt
+++ b/app/src/main/java/com/example/ouralbum/utils/Dimension.kt
@@ -1,0 +1,46 @@
+package com.example.ouralbum.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+object Dimension {
+
+    @Composable
+    fun screenWidthDp(): Int {
+        return LocalConfiguration.current.screenWidthDp
+    }
+
+    @Composable
+    fun screenHeightDp(): Int {
+        return LocalConfiguration.current.screenHeightDp
+    }
+
+    @Composable
+    fun scaledFont(percentOfHeight: Float): TextUnit {
+        val screenHeight = screenHeightDp()
+        return (screenHeight * percentOfHeight).sp
+    }
+
+    @Composable
+    fun scaledHeight(percentOfHeight: Float): Dp {
+        val screenHeight = screenHeightDp()
+        return (screenHeight * percentOfHeight).dp
+    }
+
+    @Composable
+    fun scaledWidth(percentOfWidth: Float): Dp {
+        val screenWidth = screenWidthDp()
+        return (screenWidth * percentOfWidth).dp
+    }
+
+    @Composable
+    fun paddingSmall(): Dp = scaledWidth(0.02f)  // 약 2% 좌우 여백
+    @Composable
+    fun paddingMedium(): Dp = scaledWidth(0.04f)
+    @Composable
+    fun paddingLarge(): Dp = scaledWidth(0.06f)
+}


### PR DESCRIPTION
- WriteScreen 기본 UI 구성 (제목, 본문, 함께한 사람, 이미지, 게시 버튼)
- TagPeopleSelector 컴포저블 구현
- UiState 및 ViewModel 분리 작성 (WriteUiState, WriteViewModel)

- Dimension.kt 기반으로 WriteScreen의 레이아웃 구성요소 (TopBar, BottomBar, 이미지, 텍스트 입력 등) 크기 비율화
- AppTopBar 컴포넌트 분리 및 수직 정렬/여백 개선
- 이미지 영역 aspectRatio(1f) 적용 + Column 스크롤 가능 처리
- 추천 인물 및 선택 인물을 AssistChip으로 통일, 스타일 구분 (outlined vs filled)