### PR TITLE
feat: 홈/갤러리/북마크 화면에 로그인 가드 및 상태 처리 개선

### DIFF
--- a/app/src/main/java/com/example/ouralbum/domain/usecase/GetPhotoUseCase.kt
+++ b/app/src/main/java/com/example/ouralbum/domain/usecase/GetPhotoUseCase.kt
@@ -8,5 +8,7 @@ import javax.inject.Inject
 class GetPhotosUseCase @Inject constructor(
     private val repository: PhotoRepository
 ) {
-    operator fun invoke(): Flow<List<Photo>> = repository.getAllPhotos()
+    operator fun invoke(): Flow<List<Photo>> {
+        return repository.getAllPhotos()
+    }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/component/EmptyView.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/EmptyView.kt
@@ -1,0 +1,23 @@
+package com.example.ouralbum.presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyView(
+    message: String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(message)
+    }
+}

--- a/app/src/main/java/com/example/ouralbum/presentation/component/ErrorView.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/ErrorView.kt
@@ -1,0 +1,31 @@
+package com.example.ouralbum.presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorView(
+    message: String,
+    onRetry: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(12.dp))
+        Button(onClick = onRetry) { Text("다시 시도") }
+    }
+}

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
@@ -6,14 +6,16 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.ouralbum.presentation.component.AppTopBar
+import com.example.ouralbum.presentation.component.EmptyView
+import com.example.ouralbum.presentation.component.ErrorView
 import com.example.ouralbum.presentation.component.LoginRequiredView
 import com.example.ouralbum.presentation.component.PhotoCard
 import com.example.ouralbum.ui.util.Dimension
@@ -26,38 +28,50 @@ fun BookmarkScreen(viewModel: BookmarkViewModel = hiltViewModel()) {
     val spacingTiny = Dimension.scaledWidth(0.001f)
 
     Scaffold(
-        topBar = {
-            AppTopBar(
-                title = "Bookmark"
-            )
-        }
+        topBar = { AppTopBar(title = "Bookmark") }
     ) { paddingValues ->
-        if (!isLoggedIn) {
-            Box(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .fillMaxSize()
-            ) {
-                LoginRequiredView()
-            }
-            return@Scaffold
-        }
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(2),
+        Box(
             modifier = Modifier
                 .padding(paddingValues)
-                .fillMaxSize(),
-            contentPadding = PaddingValues(spacingTiny),
-            verticalArrangement = Arrangement.spacedBy(spacingTiny),
-            horizontalArrangement = Arrangement.spacedBy(spacingTiny)
+                .fillMaxSize()
         ) {
-            items(uiState.bookmarkedPhotos) { photo ->
-                PhotoCard(
-                    photo = photo,
-                    onBookmarkClick = { viewModel.onBookmarkClick(photo.id) }
-                )
+            when {
+                !isLoggedIn -> {
+                    LoginRequiredView()
+                }
+
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                uiState.error != null -> {
+                    ErrorView(
+                        message = uiState.error ?: "알 수 없는 오류가 발생했습니다.",
+                        onRetry = { viewModel.reload() }
+                    )
+                }
+
+                uiState.bookmarkedPhotos.isEmpty() -> {
+                    EmptyView("북마크된 게시물이 없습니다.")
+                }
+
+                else -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(2),
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(spacingTiny),
+                        verticalArrangement = Arrangement.spacedBy(spacingTiny),
+                        horizontalArrangement = Arrangement.spacedBy(spacingTiny)
+                    ) {
+                        items(uiState.bookmarkedPhotos, key = { it.id }) { photo ->
+                            PhotoCard(
+                                photo = photo,
+                                onBookmarkClick = { viewModel.onBookmarkClick(photo.id) }
+                            )
+                        }
+                    }
+                }
             }
         }
-
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkViewModel.kt
@@ -69,10 +69,15 @@ class BookmarkViewModel @Inject constructor(
         }
     }
 
+    fun reload() {
+        // 로그인일 때만 재시도 허용
+        if (isLoggedIn.value) loadBookmarkedPhotos()
+    }
+
     fun onBookmarkClick(photoId: String) {
         viewModelScope.launch {
             toggleBookmarkUseCase(photoId)
-            if (isLoggedIn.value) loadBookmarkedPhotos()
+            reload() // 북마크 후 재로딩
         }
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.ouralbum.presentation.component.AppTopBar
+import com.example.ouralbum.presentation.component.EmptyView
+import com.example.ouralbum.presentation.component.ErrorView
 import com.example.ouralbum.presentation.component.LoginRequiredView
 import com.example.ouralbum.presentation.component.PhotoCard
 
@@ -48,7 +50,7 @@ fun GalleryScreen(
 
                 else -> {
                     if (uiState.photos.isEmpty()) {
-                        EmptyView()
+                        EmptyView("업로드된 게시물이 없습니다.")
                     } else {
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
@@ -65,36 +67,5 @@ fun GalleryScreen(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun ErrorView(
-    message: String,
-    onRetry: () -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 24.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(message, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
-        Spacer(Modifier.height(12.dp))
-        Button(onClick = onRetry) { Text("다시 시도") }
-    }
-}
-
-@Composable
-private fun EmptyView() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 24.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text("업로드된 사진이 없습니다.")
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
@@ -5,34 +5,62 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.ouralbum.presentation.component.AppTopBar
 import com.example.ouralbum.presentation.component.PhotoCard
+import com.example.ouralbum.presentation.component.ErrorView
+import com.example.ouralbum.presentation.component.EmptyView
+import com.example.ouralbum.presentation.component.LoginRequiredView
 
 @Composable
 fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
+    val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle(initialValue = false)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
-        topBar = {
-            AppTopBar(
-                title = "Our Album"
-            )
-        }
+        topBar = { AppTopBar(title = "Our Album") }
     ) { paddingValues ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
         ) {
-            items(uiState.photos) { photo ->
-                PhotoCard(
-                    photo = photo,
-                    onBookmarkClick = { viewModel.onBookmarkClick(photo.id) }
-                )
+            when {
+                !isLoggedIn -> {
+                    LoginRequiredView()
+                }
+
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                uiState.error != null -> {
+                    ErrorView(
+                        message = uiState.error ?: "알 수 없는 오류가 발생했습니다.",
+                        onRetry = { viewModel.reload() }
+                    )
+                }
+
+                uiState.photos.isEmpty() -> {
+                    EmptyView("피드에 게시물이 없습니다.")
+                }
+
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(uiState.photos, key = { it.id }) { photo ->
+                            PhotoCard(
+                                photo = photo,
+                                onBookmarkClick = { viewModel.onBookmarkClick(photo.id) }
+                            )
+                        }
+                    }
+                }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeViewModel.kt
@@ -2,44 +2,87 @@ package com.example.ouralbum.presentation.screen.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.ouralbum.domain.auth.AuthStateProvider
 import com.example.ouralbum.domain.usecase.GetPhotosUseCase
 import com.example.ouralbum.domain.usecase.ToggleBookmarkUseCase
+import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getPhotosUseCase: GetPhotosUseCase,
-    private val toggleBookmarkUseCase: ToggleBookmarkUseCase
+    private val toggleBookmarkUseCase: ToggleBookmarkUseCase,
+    authStateProvider: AuthStateProvider
 ) : ViewModel() {
 
+    // 로그인 상태 (GalleryViewModel과 동일 패턴)
+    val isLoggedIn: StateFlow<Boolean> = authStateProvider.isLoggedIn
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    // UI 상태
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState
 
+    // 최초 구독: 로그인되면 로드, 로그아웃되면 초기화
     init {
-        loadPhotos()
+        viewModelScope.launch {
+            isLoggedIn.collect { loggedIn ->
+                if (loggedIn) {
+                    loadPhotos()
+                } else {
+                    _uiState.value = HomeUiState() // 로그아웃 시 초기화
+                }
+            }
+        }
     }
 
+    // 중복 로딩 방지 플래그
+    private var isLoadingPhotos = false
+
     private fun loadPhotos() {
+        if (isLoadingPhotos) return
+        isLoadingPhotos = true
         viewModelScope.launch {
             getPhotosUseCase()
-                .onStart { _uiState.value = _uiState.value.copy(isLoading = true) }
-                .catch { e -> _uiState.value = _uiState.value.copy(isLoading = false, error = e.message) }
+                .onStart {
+                    _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+                }
+                .catch { e ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = e.message ?: "사진 로드 실패"
+                    )
+                    isLoadingPhotos = false
+                }
                 .collect { photos ->
-                    _uiState.value = HomeUiState(photos = photos, isLoading = false)
+                    _uiState.value = _uiState.value.copy(
+                        photos = photos,
+                        isLoading = false,
+                        error = null
+                    )
+                    isLoadingPhotos = false
                 }
         }
+    }
+
+    fun reload() {
+        if (isLoggedIn.value) loadPhotos() // 로그인 시에만 재시도
     }
 
     fun onBookmarkClick(photoId: String) {
         viewModelScope.launch {
             toggleBookmarkUseCase(photoId)
-            loadPhotos() // 북마크 상태 업데이트 후 새로고침
+            reload() // 북마크 후 새로고침
         }
     }
 }


### PR DESCRIPTION
- 홈 피드도 Firestore 보안 규칙을 로그인 사용자만 접근 가능하도록 변경
- Repository
  - getAllPhotos()에서 snapshotListener 에러 시 close(error) 호출하여 로딩 무한루프 방지
- Screen
  - ErrorView, EmptyView 공통 컴포넌트로 분리하여 재사용
  - 로그인 여부(isLoggedIn)에 따라 LoginRequiredView 표시
  - 로딩/에러/빈 상태/정상 데이터 표시 로직 통일
- ViewModel
  - AuthStateProvider 구독하여 로그인 상태 반영
  - 로그인 시 데이터 로드, 로그아웃 시 상태 초기화
  - 중복 로딩 방지 플래그 추가
  - 북마크 토글 시 reload 처리