### PR TITLE
feat(navigation): 로그인 상태에 따른 시작 화면 분기

### DIFF
--- a/app/src/main/java/com/example/ouralbum/OurAlbumNavHost.kt
+++ b/app/src/main/java/com/example/ouralbum/OurAlbumNavHost.kt
@@ -2,6 +2,7 @@ package com.example.ouralbum
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -10,19 +11,39 @@ import com.example.ouralbum.presentation.screen.gallery.GalleryScreen
 import com.example.ouralbum.presentation.screen.home.HomeScreen
 import com.example.ouralbum.presentation.screen.write.WriteScreen
 import com.example.ouralbum.presentation.navigation.NavigationItem
+import com.example.ouralbum.presentation.navigation.Routes
 import com.example.ouralbum.presentation.screen.login.LoginScreen
 import com.example.ouralbum.presentation.screen.mypage.MyPageRoute
+import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun OurAlbumNavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
+    val startDestination = if (FirebaseAuth.getInstance().currentUser != null) {
+        NavigationItem.Home.route
+    } else {
+        Routes.Login
+    }
+
     NavHost(
         navController = navController,
-        startDestination = NavigationItem.Home.route,
+        startDestination = startDestination,
         modifier = modifier
     ) {
+        composable(Routes.Login) {
+            LoginScreen(
+                navController = navController,
+                onLoginSuccess = {
+                    // 로그인 성공 시 홈으로 이동 + 로그인 스택 제거
+                    navController.navigate(NavigationItem.Home.route) {
+                        popUpTo(Routes.Login) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
         composable(NavigationItem.Home.route) {
             HomeScreen()
         }
@@ -38,16 +59,5 @@ fun OurAlbumNavHost(
         composable(NavigationItem.MyPage.route) {
             MyPageRoute(navController = navController)
         }
-
-        // 로그인 화면 추가
-        composable("login") {
-            LoginScreen(
-                navController = navController,
-                onLoginSuccess = {
-                    navController.popBackStack()
-                }
-            )
-        }
     }
 }
-

--- a/app/src/main/java/com/example/ouralbum/presentation/navigation/Routes.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/navigation/Routes.kt
@@ -1,0 +1,5 @@
+package com.example.ouralbum.presentation.navigation
+
+object Routes {
+    const val Login = "login"
+}

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/main/MainScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/main/MainScreen.kt
@@ -4,23 +4,39 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.example.ouralbum.OurAlbumNavHost
 import com.example.ouralbum.presentation.component.CustomBottomNavigationBar
+import com.example.ouralbum.presentation.navigation.NavigationItem
 
 @Composable
 fun MainScreen(navController: NavHostController) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentDestination = navBackStackEntry?.destination
+    val currentRoute = navBackStackEntry?.destination?.route
 
+    // 바텀바를 보여줄 라우트(탭)만 정의
+    val bottomBarRoutes = remember {
+        setOf(
+            NavigationItem.Home.route,
+            NavigationItem.Gallery.route,
+            NavigationItem.Write.route,
+            NavigationItem.Bookmark.route,
+            NavigationItem.MyPage.route
+        )
+    }
+    val showBottomBar = currentRoute in bottomBarRoutes
+    // 로그인/온보딩 등은 바텀바 숨김: currentRoute == Routes.Login 일 때 false
     Scaffold(
         bottomBar = {
-            CustomBottomNavigationBar(
-                navController = navController,
-                currentRoute = currentDestination?.route
-            )
+            if (showBottomBar) {
+                CustomBottomNavigationBar(
+                    navController = navController,
+                    currentRoute = currentRoute
+                )
+            }
         }
     ) { innerPadding ->
         OurAlbumNavHost(


### PR DESCRIPTION
- NavHost의 startDestination을 FirebaseAuth 로그인 상태에 따라 분기하도록 수정
  - 로그인된 경우 → MyPage 화면부터 시작
  - 미로그인 상태 → Login 화면부터 시작
- Login 성공 시 Home 화면으로 이동하면서 Login 스택 제거 처리
- MainScreen에서 Login 화면일 경우 바텀바가 노출되지 않도록 조건 처리