### PR TITLE
refactor: PhotoDetailScreen, PhotoCard UI 단순화 및 패딩 구조 개선

### DIFF
--- a/app/src/main/java/com/example/ouralbum/OurAlbumNavHost.kt
+++ b/app/src/main/java/com/example/ouralbum/OurAlbumNavHost.kt
@@ -108,7 +108,8 @@ fun OurAlbumNavHost(
             arguments = listOf(navArgument("photoId") { type = NavType.StringType })
         ) {
             PhotoEditScreen(
-                onDone = { navController.popBackStack() } // 저장 후 상세로 자동 복귀
+                onDone = { navController.popBackStack() },
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
@@ -1,5 +1,6 @@
 package com.example.ouralbum.presentation.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
@@ -9,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -24,62 +27,52 @@ fun PhotoCard(
     modifier: Modifier = Modifier
 ) {
     val fontSizeTitle = Dimension.scaledFont(0.02f)
-    val fontSizeDate = Dimension.scaledFont(0.018f)
+    val fontSizeDate = Dimension.scaledFont(0.017f)
     val iconSize = Dimension.scaledWidth(0.06f)
     val paddingHorizontal = Dimension.paddingSmall()
     val paddingVertical = Dimension.scaledHeight(0.01f)
 
-    Card(
-        onClick = onClick,
+    Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = paddingHorizontal, vertical = paddingVertical / 2),
-        shape = MaterialTheme.shapes.medium,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            .clickable { onClick() }
     ) {
-        Column(Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = paddingHorizontal, vertical = paddingVertical),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = photo.title,
-                    style = MaterialTheme.typography.bodyLargeBold.copy(fontSize = fontSizeTitle),
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1
-                )
-
-                Text(
-                    text = photo.date,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeDate),
-                    modifier = Modifier.padding(end = paddingHorizontal),
-                    maxLines = 1
-                )
-
-                IconButton(
-                    onClick = onBookmarkClick,
-                    modifier = Modifier.size(iconSize)
-                ) {
-                    Icon(
-                        imageVector = if (photo.isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
-                        contentDescription = "북마크"
-                    )
-                }
-            }
-
-            AsyncImage(
-                model = photo.imageUrl,
-                contentDescription = "사진: ${photo.title}",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f) // 정사각형
-                    .clip(MaterialTheme.shapes.medium)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingHorizontal, vertical = paddingVertical),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = photo.title,
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeTitle),
+                modifier = Modifier.weight(1f),
+                maxLines = 1
             )
-            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = photo.date,
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeDate),
+                modifier = Modifier.padding(end = paddingHorizontal),
+                maxLines = 1
+            )
+
+            IconButton(
+                onClick = onBookmarkClick,
+                modifier = Modifier.size(iconSize)
+            ) {
+                Icon(
+                    imageVector = if (photo.isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
+                    contentDescription = "북마크"
+                )
+            }
         }
+
+        AsyncImage(
+            model = photo.imageUrl,
+            contentDescription = "사진: ${photo.title}",
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
@@ -1,14 +1,17 @@
 package com.example.ouralbum.presentation.screen.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -24,17 +27,49 @@ fun PhotoDetailScreen(
 ) {
     val ui by viewModel.uiState.collectAsStateWithLifecycle()
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var menuExpanded by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
             AppTopBar(
                 title = ui.photo?.title ?: "상세",
-                onBack = onBack
+                onBack = onBack,
+                actions = {
+                    // 본인 글일 때만 점세개 메뉴 노출
+                    if (ui.isOwner && ui.photo != null) {
+                        Box {
+                            IconButton(onClick = { menuExpanded = true }) {
+                                Icon(Icons.Rounded.MoreVert, contentDescription = "메뉴")
+                            }
+                            val isDark = isSystemInDarkTheme()
+
+                            DropdownMenu(
+                                expanded = menuExpanded,
+                                onDismissRequest = { menuExpanded = false },
+                                modifier = Modifier.background(if (isDark) Color.Black else Color.White)
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("수정") },
+                                    onClick = {
+                                        menuExpanded = false
+                                        onEdit(ui.photo!!.id)
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("삭제", color = MaterialTheme.colorScheme.error) },
+                                    onClick = {
+                                        menuExpanded = false
+                                        showDeleteDialog = true
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             )
         }
     ) { padding ->
         Box(Modifier.padding(padding).fillMaxSize()) {
-
             when {
                 ui.isLoading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
 
@@ -46,44 +81,32 @@ fun PhotoDetailScreen(
                 ui.photo != null -> {
                     val p = ui.photo!!
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        modifier = Modifier.fillMaxSize()
                     ) {
                         item {
                             AsyncImage(
                                 model = p.imageUrl,
                                 contentDescription = p.title,
+                                contentScale = ContentScale.FillWidth,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        item {
+                            Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .aspectRatio(1f)
-                                    .then(Modifier)
-                                    .clip(RoundedCornerShape(12.dp))
-                            )
-                        }
-                        item {
-                            Text(p.title, style = MaterialTheme.typography.headlineSmall)
-                            Spacer(Modifier.height(4.dp))
-                            Text(p.date, style = MaterialTheme.typography.bodyMedium, color = Color.Gray)
-                        }
-                        item {
-                            Divider()
-                            Text(
-                                if (p.content.isBlank()) "내용 없음" else p.content,
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-                        }
-                        if (ui.isOwner) {
-                            item {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    OutlinedButton(onClick = { onEdit(p.id) }) { Text("수정") }
-                                    OutlinedButton(
-                                        onClick = { showDeleteDialog = true },
-                                        colors = ButtonDefaults.outlinedButtonColors(
-                                            contentColor = MaterialTheme.colorScheme.error
-                                        )
-                                    ) { Text("삭제") }
-                                }
+                                    .padding(horizontal = 12.dp, vertical = 12.dp)
+                            ) {
+                                Text(
+                                    if (p.content.isBlank()) "내용 없음" else p.content,
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Spacer(Modifier.height(8.dp))
+                                Text(
+                                    p.date,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.Gray
+                                )
                             }
                         }
                     }
@@ -91,17 +114,18 @@ fun PhotoDetailScreen(
             }
 
             if (showDeleteDialog) {
+                val isDark = isSystemInDarkTheme()
                 AlertDialog(
                     onDismissRequest = { showDeleteDialog = false },
-                    title = { Text("삭제하시겠어요?") },
-                    text = { Text("이미지와 게시물이 모두 삭제됩니다. 되돌릴 수 없어요.") },
+                    title = { Text("게시물을 삭제하시겠습니까?") },
                     confirmButton = {
                         TextButton(onClick = {
                             showDeleteDialog = false
                             viewModel.delete(onDeleted = onBack)
                         }) { Text("삭제") }
                     },
-                    dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("취소") } }
+                    containerColor = if (isDark) Color.Black else Color.White,
+                    dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("취소") }}
                 )
             }
         }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoEditScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoEditScreen.kt
@@ -13,6 +13,7 @@ import com.example.ouralbum.presentation.component.ErrorView
 @Composable
 fun PhotoEditScreen(
     onDone: () -> Unit,
+    onBack: () -> Unit,
     viewModel: PhotoEditViewModel = hiltViewModel()
 ) {
     val ui by viewModel.uiState.collectAsStateWithLifecycle()
@@ -21,7 +22,7 @@ fun PhotoEditScreen(
         if (ui.done) onDone()
     }
 
-    Scaffold(topBar = { AppTopBar(title = "게시물 수정") }) { padding ->
+    Scaffold(topBar = { AppTopBar(title = "게시물 수정", onBack = onBack) }) { padding ->
         when {
             ui.isLoading -> Box(Modifier.padding(padding).fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
                 CircularProgressIndicator()

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
@@ -54,8 +54,7 @@ fun GalleryScreen(
                         EmptyView("업로드된 게시물이 없습니다.")
                     } else {
                         LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(vertical = 8.dp)
+                            modifier = Modifier.fillMaxSize()
                         ) {
                             items(uiState.photos, key = { it.id }) { photo ->
                                 PhotoCard(


### PR DESCRIPTION
- LazyColumn의 전체 padding 제거
- 텍스트(date, content)를 Column으로 묶어 단일 padding 적용
- 불필요한 Spacer 및 item-level padding 정리
- 이미지 영역 꽉 채우도록 ContentScale.FillWidth 적용 -