### PR TITLE
feat: 사진 업로드 및 조회 정렬 로직 개선

### DIFF
--- a/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
+++ b/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
@@ -11,13 +11,14 @@ import com.google.firebase.firestore.DocumentSnapshot
 fun DocumentSnapshot.toPhoto(): Photo? = runCatching {
     val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
     val bookmarkedBy = (get("bookmarkedBy") as? List<*>)?.filterIsInstance<String>().orEmpty()
-
+    val ts = getTimestamp("createdAt")
     Photo(
         id = id,
         title = getString("title").orEmpty(),
         content = getString("content").orEmpty(),
         date = getString("date").orEmpty(),
         imageUrl = getString("imageUrl").orEmpty(),
-        isBookmarked = currentUserId != null && currentUserId in bookmarkedBy
+        isBookmarked = currentUserId != null && currentUserId in bookmarkedBy,
+        createdAt = ts?.toDate()?.time ?: 0L
     )
 }.getOrNull()

--- a/app/src/main/java/com/example/ouralbum/data/repository/PhotoRepositoryImpl.kt
+++ b/app/src/main/java/com/example/ouralbum/data/repository/PhotoRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.example.ouralbum.domain.model.PhotoDetail
 import com.example.ouralbum.domain.repository.PhotoRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +23,7 @@ class PhotoRepositoryImpl @Inject constructor(
 
     override fun getAllPhotos(): Flow<List<Photo>> = callbackFlow {
         val listener = firestore.collection("photos")
+            .orderBy("createdAt", Query.Direction.DESCENDING)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) { close(error); return@addSnapshotListener }
                 val photos = snapshot?.documents?.mapNotNull { it.toPhoto() } ?: emptyList()
@@ -35,6 +37,7 @@ class PhotoRepositoryImpl @Inject constructor(
         if (uid == null) { trySend(emptyList()); close(); return@callbackFlow }
         val listener = firestore.collection("photos")
             .whereEqualTo("userId", uid)
+            .orderBy("createdAt", Query.Direction.DESCENDING)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) { close(error); return@addSnapshotListener }
                 val photos = snapshot?.documents?.mapNotNull { it.toPhoto() } ?: emptyList()
@@ -48,6 +51,7 @@ class PhotoRepositoryImpl @Inject constructor(
         if (uid == null) { trySend(emptyList()); close(); return@callbackFlow }
         val listener = firestore.collection("photos")
             .whereArrayContains("bookmarkedBy", uid)
+            .orderBy("createdAt", Query.Direction.DESCENDING)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) { close(error); return@addSnapshotListener }
                 val photos = snapshot?.documents?.mapNotNull { it.toPhoto() } ?: emptyList()

--- a/app/src/main/java/com/example/ouralbum/domain/model/Photo.kt
+++ b/app/src/main/java/com/example/ouralbum/domain/model/Photo.kt
@@ -10,5 +10,6 @@ data class Photo(
     val content: String = "",
     val date: String = "",
     val imageUrl: String = "",
-    val isBookmarked: Boolean = false
+    val isBookmarked: Boolean = false,
+    val createdAt: Long
 )

--- a/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
@@ -9,14 +9,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.ouralbum.domain.model.Photo
-import com.example.ouralbum.ui.theme.bodyLargeBold
 import com.example.ouralbum.ui.util.Dimension
 
 @Composable
@@ -24,9 +21,12 @@ fun PhotoCard(
     photo: Photo,
     onBookmarkClick: () -> Unit,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    imageModifier: Modifier = Modifier.fillMaxWidth(),
+    imageContentScale: ContentScale = ContentScale.FillWidth
 ) {
     val fontSizeTitle = Dimension.scaledFont(0.02f)
+    val fontSizeContent = Dimension.scaledFont(0.018f)
     val fontSizeDate = Dimension.scaledFont(0.017f)
     val iconSize = Dimension.scaledWidth(0.06f)
     val paddingHorizontal = Dimension.paddingSmall()
@@ -71,8 +71,18 @@ fun PhotoCard(
         AsyncImage(
             model = photo.imageUrl,
             contentDescription = "사진: ${photo.title}",
-            contentScale = ContentScale.FillWidth,
-            modifier = Modifier.fillMaxWidth()
+            contentScale = imageContentScale,
+            modifier = imageModifier
+        )
+
+        Text(
+            text = if (photo.content.isBlank()) "내용 없음" else photo.content,
+            style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeContent),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingHorizontal, vertical = 4.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -70,7 +71,11 @@ fun BookmarkScreen(
                             PhotoCard(
                                 photo = photo,
                                 onBookmarkClick = { viewModel.onBookmarkClick(photo.id) },
-                                onClick = { onOpenDetail(photo.id) }
+                                onClick = { onOpenDetail(photo.id) },
+                                imageModifier = Modifier
+                                    .fillMaxWidth()
+                                    .aspectRatio(1f),
+                                imageContentScale = ContentScale.Crop
                             )
                         }
                     }


### PR DESCRIPTION
- 업로드 시 createdAt 필드(serverTimestamp) 추가
- 전체/내 게시물/북마크 조회 시 createdAt DESC 정렬 적용
- 정렬 쿼리 지원을 위한 Firestore 복합 색인(userId+createdAt, bookmarkedBy+createdAt) 생성
- UI변경점: PhotoCard에 글 내용도 보이도록 추가, 북마크 화면에서는 이미지를 정사각형으로 보이도록 수정