### PR TITLE
feat(bookmark): 북마크 아키텍처 전면 교체 및 UI 반영 일원화

### DIFF
--- a/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
+++ b/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
@@ -4,13 +4,8 @@ import com.example.ouralbum.domain.model.Photo
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 
-/**
- * Firestore 문서를 목록용 Photo로 매핑.
- * - 현재 로그인 유저 기준(isBookmarked) 계산 포함
- */
 fun DocumentSnapshot.toPhoto(): Photo? = runCatching {
     val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
-    val bookmarkedBy = (get("bookmarkedBy") as? List<*>)?.filterIsInstance<String>().orEmpty()
     val ts = getTimestamp("createdAt")
     Photo(
         id = id,
@@ -18,7 +13,6 @@ fun DocumentSnapshot.toPhoto(): Photo? = runCatching {
         content = getString("content").orEmpty(),
         date = getString("date").orEmpty(),
         imageUrl = getString("imageUrl").orEmpty(),
-        isBookmarked = currentUserId != null && currentUserId in bookmarkedBy,
         createdAt = ts?.toDate()?.time ?: 0L
     )
 }.getOrNull()

--- a/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhotoDetail.kt
+++ b/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhotoDetail.kt
@@ -6,14 +6,12 @@ import com.google.firebase.firestore.DocumentSnapshot
 
 fun DocumentSnapshot.toPhotoDetail(): PhotoDetail? = runCatching {
     val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
-    val bookmarkedBy = get("bookmarkedBy") as? List<*> ?: emptyList<Any>()
     PhotoDetail(
         id = id,
         title = getString("title") ?: "",
         content = getString("content") ?: "",
         date = getString("date") ?: "",
         imageUrl = getString("imageUrl") ?: "",
-        isBookmarked = currentUserId != null && bookmarkedBy.contains(currentUserId),
         userId = getString("userId") ?: "",
         storagePath = getString("storagePath") // 선택 저장 필드(없어도 동작)
     )

--- a/app/src/main/java/com/example/ouralbum/data/remote/PhotoUploader.kt
+++ b/app/src/main/java/com/example/ouralbum/data/remote/PhotoUploader.kt
@@ -52,7 +52,6 @@ class PhotoUploader @Inject constructor(
                 "date" to getCurrentDate(),
                 "imageUrl" to imageUrl,
                 "userId" to userId,
-                "bookmarkedBy" to emptyList<String>(),
                 "createdAt" to FieldValue.serverTimestamp()
             )
 

--- a/app/src/main/java/com/example/ouralbum/domain/model/Photo.kt
+++ b/app/src/main/java/com/example/ouralbum/domain/model/Photo.kt
@@ -10,6 +10,5 @@ data class Photo(
     val content: String = "",
     val date: String = "",
     val imageUrl: String = "",
-    val isBookmarked: Boolean = false,
     val createdAt: Long
 )

--- a/app/src/main/java/com/example/ouralbum/domain/model/PhotoDetail.kt
+++ b/app/src/main/java/com/example/ouralbum/domain/model/PhotoDetail.kt
@@ -6,7 +6,6 @@ data class PhotoDetail(
     val content: String,
     val date: String,
     val imageUrl: String,
-    val isBookmarked: Boolean,
 
     // 상세 전용 필드
     val userId: String,          // 글 작성자 식별 (수정/삭제 버튼 노출 판단)

--- a/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
@@ -1,6 +1,7 @@
 package com.example.ouralbum.presentation.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
@@ -9,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -19,6 +21,7 @@ import com.example.ouralbum.ui.util.Dimension
 @Composable
 fun PhotoCard(
     photo: Photo,
+    bookmarked: Boolean,
     onBookmarkClick: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -31,6 +34,9 @@ fun PhotoCard(
     val iconSize = Dimension.scaledWidth(0.06f)
     val paddingHorizontal = Dimension.paddingSmall()
     val paddingVertical = Dimension.scaledHeight(0.01f)
+
+    val isDark = isSystemInDarkTheme()
+    val contentColor = if (isDark) Color.White else Color.Black
 
     Column(
         modifier = modifier
@@ -57,13 +63,16 @@ fun PhotoCard(
                 maxLines = 1
             )
 
-            IconButton(
-                onClick = onBookmarkClick,
+            // 아이콘은 외부의 bookmarked만 사용 (로컬 상태 X)
+            IconToggleButton(
+                checked = bookmarked,
+                onCheckedChange = { onBookmarkClick() },
                 modifier = Modifier.size(iconSize)
             ) {
                 Icon(
-                    imageVector = if (photo.isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
-                    contentDescription = "북마크"
+                    imageVector = if (bookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
+                    contentDescription = if (bookmarked) "북마크됨" else "북마크",
+                    tint = contentColor
                 )
             }
         }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
@@ -70,6 +70,7 @@ fun BookmarkScreen(
                         items(uiState.bookmarkedPhotos, key = { it.id }) { photo ->
                             PhotoCard(
                                 photo = photo,
+                                bookmarked = true,
                                 onBookmarkClick = { viewModel.onBookmarkClick(photo.id) },
                                 onClick = { onOpenDetail(photo.id) },
                                 imageModifier = Modifier

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkViewModel.kt
@@ -29,6 +29,9 @@ class BookmarkViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(BookmarkUiState())
     val uiState: StateFlow<BookmarkUiState> = _uiState
 
+    // 토글 중복 클릭 방지 (photoId별)
+    private val toggling = mutableSetOf<String>()
+
     init {
         // 로그인 변화에 반응
         viewModelScope.launch {
@@ -75,9 +78,26 @@ class BookmarkViewModel @Inject constructor(
     }
 
     fun onBookmarkClick(photoId: String) {
+        // 로그인 상태 체크(방어)
+        if (!isLoggedIn.value || photoId.isBlank()) return
+        // 토글 중복 클릭 방지
+        if (!toggling.add(photoId)) return // 이미 토글 중이면 return
+
         viewModelScope.launch {
-            toggleBookmarkUseCase(photoId)
-            reload() // 북마크 후 재로딩
+            // 토글 시에는 목록 로딩 스피너를 건드리지 않음 (isLoading 유지)
+            runCatching { toggleBookmarkUseCase(photoId) }
+                .onSuccess {
+                    // 성공 시 별도 reload/load 호출 불필요
+                    // GetBookmarkedPhotosUseCase 흐름이 실시간으로 반영
+                }
+                .onFailure { e ->
+                    _uiState.value = _uiState.value.copy(
+                        // 목록 로딩 상태는 건드리지 않음
+                        error = e.message ?: "북마크 처리에 실패했습니다."
+                    )
+                }
+            toggling.remove(photoId) // 해제
         }
     }
+
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ExperimentalMaterial3Api
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PhotoDetailScreen(
     onBack: () -> Unit,
@@ -38,6 +38,9 @@ fun PhotoDetailScreen(
 ) {
     val ui by viewModel.uiState.collectAsStateWithLifecycle()
     val commentUi by viewModel.commentUiState.collectAsStateWithLifecycle()
+
+    val isBookmarked by viewModel.isBookmarked.collectAsStateWithLifecycle()
+
     var showDeleteDialog by remember { mutableStateOf(false) }
     var menuExpanded by remember { mutableStateOf(false) }
 
@@ -46,8 +49,6 @@ fun PhotoDetailScreen(
     val isDark = isSystemInDarkTheme()
     val contentColor = if (isDark) Color.White else Color.Black
     val containerColor = if (isDark) Color.Black else Color.White
-
-    val isBookmarked = ui.photo?.isBookmarked == true
 
     LaunchedEffect(commentUi.opened) {
         if (commentUi.opened) {

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryScreen.kt
@@ -26,6 +26,8 @@ fun GalleryScreen(
 ) {
     val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle(initialValue = false)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // 내가 북마크한 photoId 집합 구독
+    val bookmarkedIds by viewModel.bookmarkedIds.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = { AppTopBar(title = "My Album") }
@@ -59,6 +61,7 @@ fun GalleryScreen(
                             items(uiState.photos, key = { it.id }) { photo ->
                                 PhotoCard(
                                     photo = photo,
+                                    bookmarked = bookmarkedIds.contains(photo.id),
                                     onBookmarkClick = { viewModel.onBookmarkClick(photo.id) },
                                     onClick = { onOpenDetail(photo.id) }
                                 )

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/gallery/GalleryViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.ouralbum.domain.auth.AuthStateProvider
 import com.example.ouralbum.domain.usecase.GetUserPhotosUseCase
 import com.example.ouralbum.domain.usecase.ToggleBookmarkUseCase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -14,7 +17,9 @@ import javax.inject.Inject
 class GalleryViewModel @Inject constructor(
     private val getUserPhotosUseCase: GetUserPhotosUseCase,
     private val toggleBookmarkUseCase: ToggleBookmarkUseCase,
-    authStateProvider: AuthStateProvider
+    authStateProvider: AuthStateProvider,
+    private val firestore: FirebaseFirestore,
+    private val auth: FirebaseAuth
     ) : ViewModel() {
 
     val isLoggedIn: StateFlow<Boolean> = authStateProvider.isLoggedIn
@@ -24,48 +29,111 @@ class GalleryViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(GalleryUiState())
     val uiState: StateFlow<GalleryUiState> = _uiState
 
+    // 내가 북마크한 photoId 집합 (UI에서 아이콘 상태 판단용)
+    private val _bookmarkedIds = MutableStateFlow<Set<String>>(emptySet())
+    val bookmarkedIds: StateFlow<Set<String>> = _bookmarkedIds
+
+    // 내부 상태
+    private var isLoadingPhotos = false
+    private val toggling = mutableSetOf<String>()        // 토글 중복 클릭 방지
+    private var bookmarkListener: ListenerRegistration? = null // 리스너 해제용
+
     init {
         // 로그인 상태 변화에 반응해 사진 로드/초기화
         viewModelScope.launch {
             isLoggedIn.collect { loggedIn ->
                 if (loggedIn) {
                     loadUserPhotos()
+                    attachBookmarks()
                 } else {
                     // 로그아웃시 화면 초기화
+                    detachBookmarks()
+                    _bookmarkedIds.value = emptySet()
                     _uiState.value = GalleryUiState()
                 }
             }
         }
     }
 
-    // 중복 로딩 방지
-    private var isLoadingPhotos = false
-
     private fun loadUserPhotos() {
         if (isLoadingPhotos) return
         isLoadingPhotos = true
         viewModelScope.launch {
             getUserPhotosUseCase()
-                .onStart { _uiState.value = _uiState.value.copy(isLoading = true, error = null) }
+                .onStart {
+                    _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+                }
                 .catch { e ->
-                    _uiState.value = _uiState.value.copy(isLoading = false, error = e.message ?: "사진 로드 실패")
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = e.message ?: "사진 로드 실패"
+                    )
                     isLoadingPhotos = false
                 }
                 .collect { photos ->
-                    _uiState.value = _uiState.value.copy(photos = photos, isLoading = false, error = null)
+                    _uiState.value = _uiState.value.copy(
+                        photos = photos,
+                        isLoading = false,
+                        error = null
+                    )
                     isLoadingPhotos = false
                 }
         }
     }
 
     fun reload() {
-        // 로그인일 때만 재시도 허용
-        if (isLoggedIn.value) loadUserPhotos()
+        if (isLoggedIn.value) loadUserPhotos()// 로그인 시에만 재시도
     }
 
     fun onBookmarkClick(photoId: String) {
-        viewModelScope.launch {
-            toggleBookmarkUseCase(photoId)
+        if (!isLoggedIn.value || photoId.isBlank()) return
+        if (!toggling.add(photoId)) return
+
+        // 1) 낙관적 업데이트
+        val before = _bookmarkedIds.value
+        val optimistic = before.toMutableSet().apply {
+            if (!add(photoId)) remove(photoId)
         }
+        _bookmarkedIds.value = optimistic
+
+        // 2) 서버 반영
+        viewModelScope.launch {
+            runCatching { toggleBookmarkUseCase(photoId) }
+                .onFailure { e ->
+                    // 3) 실패 시 롤백
+                    _bookmarkedIds.value = before
+                    _uiState.value = _uiState.value.copy(
+                        error = e.message ?: "북마크 처리에 실패했습니다."
+                    )
+                }
+            // 4) 중복 방지 해제
+            toggling.remove(photoId)
+        }
+    }
+
+    // 내 북마크 상태 실시간 구독: users/{uid}/bookmarks
+    private fun attachBookmarks() {
+        bookmarkListener?.remove()
+        val uid = auth.currentUser?.uid ?: run {
+            _bookmarkedIds.value = emptySet()
+            return
+        }
+        bookmarkListener = firestore.collection("users")
+            .document(uid)
+            .collection("bookmarks")
+            .addSnapshotListener { snap, e ->
+                if (e != null) return@addSnapshotListener
+                _bookmarkedIds.value = snap?.documents?.map { it.id }?.toSet() ?: emptySet()
+            }
+    }
+
+    private fun detachBookmarks() {
+        bookmarkListener?.remove()
+        bookmarkListener = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        detachBookmarks()
     }
 }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/home/HomeScreen.kt
@@ -22,6 +22,7 @@ fun HomeScreen(
 ) {
     val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle(initialValue = false)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val bookmarkedIds by viewModel.bookmarkedIds.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = { AppTopBar(title = "Our Album") }
@@ -58,6 +59,7 @@ fun HomeScreen(
                         items(uiState.photos, key = { it.id }) { photo ->
                             PhotoCard(
                                 photo = photo,
+                                bookmarked = bookmarkedIds.contains(photo.id),
                                 onBookmarkClick = { viewModel.onBookmarkClick(photo.id) },
                                 onClick = { onOpenDetail(photo.id) }
                             )


### PR DESCRIPTION
[Firestore]

- rules: users/{userId}/bookmarks/{photoId} 경로 추가(본인만 read/write)
- 기존 photos/** 규칙 유지(타인 글 update 불가)

[PhotoRepositoryImpl]

- 북마크 저장소를 photos/{photoId} → users/{uid}/bookmarks/{photoId} 트랜잭션으로 변경
- getBookmarkedPhotos(): 내 북마크 서브컬렉션 → photos를whereIn(documentId, chunked(10))으로 배치 조회
- 기존 bookmarkedBy 배열 의존 로직 제거

[Domain/Model & Mapper]

- Photo: isBookmarked 필드 제거(SSOT를 ViewModel 상태로 이전)
- toPhoto(), toPhotoDetail(): isBookmarked/bookmarkedBy 등 과거 필드 무시하도록 정리

[UseCase]

- ToggleBookmarkUseCase: Repository 위임 그대로 사용(내부 구현 변경에 맞춤)

[HomeViewModel, GalleryViewModel]

- bookmarkedIds: StateFlow<Set<String>> 추가( users/{uid}/bookmarks 스냅샷 구독 )
- onBookmarkClick() 예외 처리 및 photoId 단위 중복 클릭 방지
- 성공 후 강제 reload 최소화(실시간 반영에 의존)
- 토글 시 예외 처리(낙관적 UI)

[BookmarkViewModel]

- 목록 Flow 실시간 반영 의존(토글 성공 후 별도 reload 호출 제거)
- 중복 클릭 방지/예외 처리 추가

[PhotoDetailViewModel]

- isBookmarked: StateFlow<Boolean> 추가(단일 문서 users/{uid}/bookmarks/{photoId} 스냅샷 구독)

- 토글 시 예외 처리(낙관적 UI)

[UI]

- 아이콘 상태는 외부에서 전달받은 bookmarked만 사용(로컬 상태/photo.isBookmarked 참조 제거)

[버그 수정]

- 타인 글 북마크 시 PERMISSION_DENIED로 앱 종료되던 문제 해결(문서 수정 → 사용자 전용 경로 쓰기 전환)