### PR TITLE
feat: 상세 화면에 작성자 아바타/닉네임 추가 및 북마크 화면 날짜 숨김 제어

### DIFF
--- a/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
+++ b/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhoto.kt
@@ -14,7 +14,7 @@ fun DocumentSnapshot.toPhoto(): Photo? = runCatching {
         date = getString("date").orEmpty(),
         imageUrl = getString("imageUrl").orEmpty(),
         createdAt = ts.toDate().time,
-        authorName = getString("authorName"),            // ★ 닉네임
-        authorPhotoUrl = getString("authorPhotoUrl")     // ★ 프로필
+        authorName = getString("authorName"),            // 닉네임
+        authorPhotoUrl = getString("authorPhotoUrl")     // 프로필
     )
 }.getOrNull()

--- a/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhotoDetail.kt
+++ b/app/src/main/java/com/example/ouralbum/data/mapper/DocumentSnapShot/toPhotoDetail.kt
@@ -13,6 +13,8 @@ fun DocumentSnapshot.toPhotoDetail(): PhotoDetail? = runCatching {
         date = getString("date") ?: "",
         imageUrl = getString("imageUrl") ?: "",
         userId = getString("userId") ?: "",
-        storagePath = getString("storagePath") // 선택 저장 필드(없어도 동작)
+        storagePath = getString("storagePath"), // 선택 저장 필드(없어도 동작)
+        authorName = getString("authorName"), // 닉네임
+        authorPhotoUrl = getString("authorPhotoUrl") // 프로필
     )
 }.getOrNull()

--- a/app/src/main/java/com/example/ouralbum/domain/model/PhotoDetail.kt
+++ b/app/src/main/java/com/example/ouralbum/domain/model/PhotoDetail.kt
@@ -9,5 +9,9 @@ data class PhotoDetail(
 
     // 상세 전용 필드
     val userId: String,          // 글 작성자 식별 (수정/삭제 버튼 노출 판단)
-    val storagePath: String? = null // 선택: 문서에 별도로 저장 시 사용, 없으면 imageUrl로 Storage 참조 삭제
+    val storagePath: String? = null, // 선택: 문서에 별도로 저장 시 사용, 없으면 imageUrl로 Storage 참조 삭제
+
+    // 작성자 메타
+    val authorName: String? = null,          // 구글 닉네임
+    val authorPhotoUrl: String? = null       // 구글 프로필 이미지
 )

--- a/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/component/PhotoCard.kt
@@ -31,7 +31,8 @@ fun PhotoCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     imageModifier: Modifier = Modifier.fillMaxWidth(),
-    imageContentScale: ContentScale = ContentScale.FillWidth
+    imageContentScale: ContentScale = ContentScale.FillWidth,
+    showDate: Boolean = true
 ) {
     val fontSizeTitle = Dimension.scaledFont(0.02f)
     val fontSizeContent = Dimension.scaledFont(0.018f)
@@ -111,12 +112,14 @@ fun PhotoCard(
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = photo.date,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeDate),
-                    maxLines = 1
-                )
-                Spacer(Modifier.width(6.dp))
+                if (showDate) {
+                    Text(
+                        text = photo.date,
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSizeDate),
+                        maxLines = 1
+                    )
+                    Spacer(Modifier.width(6.dp))
+                }
                 IconToggleButton(
                     checked = bookmarked,
                     onCheckedChange = { onBookmarkClick() },

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/bookmark/BookmarkScreen.kt
@@ -76,7 +76,8 @@ fun BookmarkScreen(
                                 imageModifier = Modifier
                                     .fillMaxWidth()
                                     .aspectRatio(1f),
-                                imageContentScale = ContentScale.Crop
+                                imageContentScale = ContentScale.Crop,
+                                showDate = false
                             )
                         }
                     }

--- a/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
+++ b/app/src/main/java/com/example/ouralbum/presentation/screen/detail/PhotoDetailScreen.kt
@@ -29,6 +29,9 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.draw.clip
+import com.example.ouralbum.domain.model.Photo
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PhotoDetailScreen(
@@ -112,6 +115,53 @@ fun PhotoDetailScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize()
                     ) {
+                        // 작성자 헤더(프로필 + 닉네임)
+                        item {
+                            val avatarSize = 40.dp
+                            val avatarBg = MaterialTheme.colorScheme.surfaceVariant
+                            val isDark = isSystemInDarkTheme()
+                            val contentColor = if (isDark) Color.White else Color.Black
+
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                // 원형 프로필
+                                val authorPhotoUrl = p.authorPhotoUrl
+                                if (!authorPhotoUrl.isNullOrBlank()) {
+                                    AsyncImage(
+                                        model = authorPhotoUrl,
+                                        contentDescription = "작성자 프로필",
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier
+                                            .size(avatarSize)
+                                            .clip(shape = androidx.compose.foundation.shape.CircleShape)
+                                    )
+                                } else {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(avatarSize)
+                                            .clip(androidx.compose.foundation.shape.CircleShape)
+                                            .background(avatarBg)
+                                    )
+                                }
+
+                                Spacer(Modifier.width(10.dp))
+
+                                // 닉네임
+                                Column(modifier = Modifier.weight(1f)) {
+                                    val name = p.authorName.orEmpty()
+                                    Text(
+                                        text = if (name.isNotBlank()) name else "알 수 없음",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1
+                                    )
+                                }
+                            }
+                        }
                         // 사진
                         item {
                             AsyncImage(


### PR DESCRIPTION
[PhotoCard]

- showDate: Boolean = true 파라미터 추가로 날짜 노출 여부 제어

- 날짜 Text를 if (showDate)로 조건부 렌더링

[BookmarkScreen]

- PhotoCard(..., showDate = false)로 북마크 화면에서만 날짜 비노출

[PhotoDetailScreen]

- AppTopBar 아래에 작성자 헤더(원형 프로필 이미지 + 닉네임) 추가

[Domain / Mapper]

- PhotoDetail에 authorName: String?, authorPhotoUrl: String? 필드 추가

- DocumentSnapshot.toPhotoDetail()에서 위 필드 매핑 추가